### PR TITLE
Fixing template to do syllabus layout correctly

### DIFF
--- a/_includes/syllabus.html
+++ b/_includes/syllabus.html
@@ -14,7 +14,7 @@
 
   <table class="table table-striped">
   <tr>
-    <td class="col-md-1"></td>
+    {% if multiday %}<td class="col-md-1"></td>{% endif %}
     <td class="col-md-1"></td>
     <td class="col-md-3"><a href="{{ page.root }}/setup">Setup</a></td>
     <td class="col-md-7">Dowload files used on the lesson.</td>


### PR DESCRIPTION
`_includes/syllabus.html` didn't have an `if` around a column layout directive for the setup instructions, so the page was rendering incorrectly.